### PR TITLE
Work around Celery bug #5409 leaving stale pid files

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -49,6 +49,9 @@ cd ${APP_PATH}/checks
 cd ${APP_PATH}
 ./manage.py migrate checks
 
+# remove stale Celery .pid files (fixed in Celery 4.4.0, see https://github.com/celery/celery/issues/5409)
+rm -f *.pid
+
 # Start Celery
 celery -A internetnl multi start \
     worker db_worker slow_db_worker \


### PR DESCRIPTION
When stopping the app docker container, stale pid files are left by [Celery bug #5409](https://github.com/celery/celery/issues/5409). These prevent normal startup of the celery workers on a restart, resulting in a time-out of celery-ping.sh and unsuccessful container startup.

This is supposedly fixed in Celery 4.4.0. For now, work around the issue by removing stale pid files in `entrypoint.sh`.