### PR TITLE
Use pg_isready to check db availability on startup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && \
         libssl-dev=1.1.1b\* \
         libwww-perl \
         openssl=1.1.1b\* \
+        postgresql-client-11 \
         postgresql-server-dev-11 \
         python3-gdbm \
         python3.7 \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -45,8 +45,11 @@ sed \
 cd ${APP_PATH}/checks
 ../manage.py compilemessages
 
-# Prepare the database for use
 cd ${APP_PATH}
+# Check for database connectivity
+docker/postgres-ping.sh postgresql://${POSTGRES_USER}@${POSTGRES_HOST}/${POSTGRES_DB}
+
+# Prepare the database for use
 ./manage.py migrate checks
 
 # Start Celery

--- a/docker/postgres-ping.sh
+++ b/docker/postgres-ping.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright: 2021, NLnet Labs and the Internet.nl contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+if [[ $# -gt 3 || "$1" == "--help" || "$1" == "-h" ]]; then
+    echo >&2 "Usage: $(basename $0) [<pg connection string> [<num retries=10> [<connection timeout (int seconds)=1>"
+    echo >&2 "Exits with code 0 if Postgres db is reachable, 1 otherwise."
+    exit 1
+fi
+
+CONN_STRING=${1:-postgresql://internetnl@localhost/internetnl_db1}
+MAX_RETRIES=${2:-10}
+TIMEOUT=${3:-1}
+
+TRY_COUNT=0
+while [ ${TRY_COUNT} -le ${MAX_RETRIES} ]; do
+    echo -n "Trying Postgresql server [${TRY_COUNT}/${MAX_RETRIES}]: .. "
+    pg_isready -d ${CONN_STRING} -t ${TIMEOUT} 2>/dev/null
+    [ $? -eq 0 ] && break
+    let "TRY_COUNT=TRY_COUNT+1"
+done
+
+test ${TRY_COUNT} -le ${MAX_RETRIES}


### PR DESCRIPTION
Add a wrapper `postgres-ping.sh` inspired by the existing `celery-ping.sh`. This adds a dependency on postgresql-client-11 which provides pg_isready.